### PR TITLE
Update how to bundle keras

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ Suggests:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0.9000
+RoxygenNote: 7.2.1
 URL: https://github.com/simonpcouch/bundle
 BugReports: https://github.com/simonpcouch/bundle/issues
 VignetteBuilder: knitr

--- a/R/bundle_keras.R
+++ b/R/bundle_keras.R
@@ -69,12 +69,14 @@ bundle.keras.engine.training.Model <- function(x, ...) {
   rlang::check_installed("keras")
   rlang::check_dots_empty()
 
-  serialized <- keras::serialize_model(x)
+  file_loc <- tempfile()
+  keras::save_model_tf(x, file_loc)
+  serialized <- serialize(file_loc, connection = NULL)
 
   bundle_constr(
     object = serialized,
     situate = situate_constr(function(object) {
-      res <- keras::unserialize_model(object)
+      res <- keras::load_model_tf(unserialize(object))
 
       res
     }),

--- a/R/bundle_keras.R
+++ b/R/bundle_keras.R
@@ -10,8 +10,11 @@
 #'   [keras][keras::keras-package] package.
 #' @template param_unused_dots
 #' @rdname bundle_keras
-#' @seealso This method wraps [keras::serialize_model()] and
-#'   [keras::unserialize_model()].
+#' @seealso This method wraps [keras::save_model_tf()] and
+#'   [keras::load_model_tf()].
+#' @details This bundler does not currently support custom keras extensions,
+#'   such as use of a [keras::new_layer_class()] or custom metric function.
+#'   In such situations, consider using [keras::with_custom_object_scope()].
 #' @examplesIf FALSE
 #' # fit model and bundle ------------------------------------------------
 #' library(keras)

--- a/man/bundle_keras.Rd
+++ b/man/bundle_keras.Rd
@@ -50,6 +50,11 @@ Bundling a model prepares it to be saved to file and later
 restored for prediction in a new R session. See the 'Value' section for
 more information on bundles and their usage.
 }
+\details{
+This bundler does not currently support custom keras extensions,
+such as use of a \code{\link[keras:new-classes]{keras::new_layer_class()}} or custom metric function.
+In such situations, consider using \code{\link[keras:with_custom_object_scope]{keras::with_custom_object_scope()}}.
+}
 \examples{
 \dontshow{if (FALSE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # fit model and bundle ------------------------------------------------
@@ -103,8 +108,8 @@ predict(mod_unbundled, x_test)
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-This method wraps \code{\link[keras:serialize_model]{keras::serialize_model()}} and
-\code{\link[keras:serialize_model]{keras::unserialize_model()}}.
+This method wraps \code{\link[keras:save_model_tf]{keras::save_model_tf()}} and
+\code{\link[keras:save_model_tf]{keras::load_model_tf()}}.
 
 Other bundlers: 
 \code{\link{bundle.H2OAutoML}()},


### PR DESCRIPTION
Based on feedback from @t-kalinowski, we have:

- moved to `save_model_tf()` and `load_model_tf()`
- documented that we don't currently support custom keras extensions