### PR TITLE
test interactions with butcher

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
     utils
 Suggests:
     bonsai,
+    butcher,
     caret,
     callr,
     covr,

--- a/R/bundle_caret.R
+++ b/R/bundle_caret.R
@@ -12,6 +12,7 @@
 #' @details Primarily, these methods call [bundle()] on the output of
 #'   `train_model_object$finalModel`. See the class of the output of that
 #'   slot for more details on the bundling method for that object.
+#' @template butcher_details
 #' @examplesIf rlang::is_installed("caret")
 #' # fit model and bundle ------------------------------------------------
 #' library(caret)

--- a/R/bundle_embed.R
+++ b/R/bundle_embed.R
@@ -10,6 +10,7 @@
 #'   from [embed][embed::step_umap].
 #' @template param_unused_dots
 #' @seealso This method wraps [uwot::save_uwot()] and [uwot::load_uwot()].
+#' @template butcher_details
 #' @examplesIf rlang::is_installed("recipes") && rlang::is_installed("embed")
 #' # fit model and bundle ------------------------------------------------
 #' library(recipes)

--- a/R/bundle_parsnip.R
+++ b/R/bundle_parsnip.R
@@ -12,6 +12,7 @@
 #' @details Primarily, these methods call [bundle()] on the output of
 #'   [parsnip::extract_fit_engine()]. See the class of the output of that
 #'   function for more details on the bundling method for that object.
+#' @template butcher_details
 #' @examplesIf rlang::is_installed("parsnip") && rlang::is_installed("xgboost")
 #' # fit model and bundle ------------------------------------------------
 #' library(parsnip)

--- a/R/bundle_workflows.R
+++ b/R/bundle_workflows.R
@@ -12,6 +12,8 @@
 #'
 #' @details This bundler wraps [bundle.model_fit()] and [bundle.recipe()].
 #'
+#' @template butcher_details
+#'
 #' @examplesIf rlang::is_installed(c("workflows", "parsnip", "recipes", "xgboost"))
 #' # fit model and bundle ------------------------------------------------
 #' library(workflows)

--- a/R/bundle_workflows.R
+++ b/R/bundle_workflows.R
@@ -50,12 +50,14 @@ bundle.workflow <- function(x, ...) {
 
   res <- swap_element(x, "fit", "fit")
   res <- swap_element(res, "pre", "actions", "recipe", "recipe")
+  res <- swap_element(res, "pre", "mold", "blueprint", "recipe")
 
   bundle_constr(
     object = res,
     situate = situate_constr(function(object) {
       res <- bundle::swap_element(object, "fit", "fit")
       res <- bundle::swap_element(res, "pre", "actions", "recipe", "recipe")
+      res <- bundle::swap_element(res, "pre", "mold", "blueprint", "recipe")
 
       structure(res, class = !!class(x))
     }),

--- a/R/bundle_xgboost.R
+++ b/R/bundle_xgboost.R
@@ -13,6 +13,7 @@
 #' @seealso This method adapts the xgboost internal functions
 #'   `predict.xgb.Booster.handle()` and `xgb.handleToBooster()`, as well
 #'   as  [xgboost::xgb.serialize()].
+#' @template butcher_details
 #' @examplesIf rlang::is_installed("xgboost")
 #' # fit model and bundle ------------------------------------------------
 #' library(xgboost)

--- a/man-roxygen/butcher_details.R
+++ b/man-roxygen/butcher_details.R
@@ -1,9 +1,9 @@
 #' @section bundle and butcher:
-#' butcher is an R package that allows users to remove parts of a fitted model
-#' object that are not needed for prediction.
+#' The [butcher](https://butcher.tidymodels.org/) package allows you to remove
+#' parts of a fitted model object that are not needed for prediction.
 #'
 #' This bundle method is compatible with pre-butchering. That is, for a
-#' fitted model `x`, users can safely call:
+#' fitted model `x`, you can safely call:
 #'
 #' ```
 #' res <-

--- a/man-roxygen/butcher_details.R
+++ b/man-roxygen/butcher_details.R
@@ -1,0 +1,17 @@
+#' @section bundle and butcher:
+#' butcher is an R package that allows users to remove parts of a fitted model
+#' object that are not needed for prediction.
+#'
+#' This bundle method is compatible with pre-butchering. That is, for a
+#' fitted model `x`, users can safely call:
+#'
+#' ```
+#' res <-
+#'   x %>%
+#'   butcher() %>%
+#'   bundle()
+#' ```
+#'
+#' and predict with the output of `unbundle(res)` in a new R session.
+#'
+#' @md

--- a/man/bundle_caret.Rd
+++ b/man/bundle_caret.Rd
@@ -58,11 +58,11 @@ slot for more details on the bundling method for that object.
 }
 \section{bundle and butcher}{
 
-butcher is an R package that allows users to remove parts of a fitted model
-object that are not needed for prediction.
+The \href{https://butcher.tidymodels.org/}{butcher} package allows you to remove
+parts of a fitted model object that are not needed for prediction.
 
 This bundle method is compatible with pre-butchering. That is, for a
-fitted model \code{x}, users can safely call:
+fitted model \code{x}, you can safely call:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{res <-
   x \%>\%

--- a/man/bundle_caret.Rd
+++ b/man/bundle_caret.Rd
@@ -56,6 +56,23 @@ Primarily, these methods call \code{\link[=bundle]{bundle()}} on the output of
 \code{train_model_object$finalModel}. See the class of the output of that
 slot for more details on the bundling method for that object.
 }
+\section{bundle and butcher}{
+
+butcher is an R package that allows users to remove parts of a fitted model
+object that are not needed for prediction.
+
+This bundle method is compatible with pre-butchering. That is, for a
+fitted model \code{x}, users can safely call:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{res <-
+  x \%>\%
+  butcher() \%>\%
+  bundle()
+}\if{html}{\out{</div>}}
+
+and predict with the output of \code{unbundle(res)} in a new R session.
+}
+
 \examples{
 \dontshow{if (rlang::is_installed("caret")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # fit model and bundle ------------------------------------------------

--- a/man/bundle_embed.Rd
+++ b/man/bundle_embed.Rd
@@ -51,6 +51,23 @@ Bundling a model prepares it to be saved to file and later
 restored for prediction in a new R session. See the 'Value' section for
 more information on bundles and their usage.
 }
+\section{bundle and butcher}{
+
+butcher is an R package that allows users to remove parts of a fitted model
+object that are not needed for prediction.
+
+This bundle method is compatible with pre-butchering. That is, for a
+fitted model \code{x}, users can safely call:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{res <-
+  x \%>\%
+  butcher() \%>\%
+  bundle()
+}\if{html}{\out{</div>}}
+
+and predict with the output of \code{unbundle(res)} in a new R session.
+}
+
 \examples{
 \dontshow{if (rlang::is_installed("recipes") && rlang::is_installed("embed")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # fit model and bundle ------------------------------------------------

--- a/man/bundle_embed.Rd
+++ b/man/bundle_embed.Rd
@@ -53,11 +53,11 @@ more information on bundles and their usage.
 }
 \section{bundle and butcher}{
 
-butcher is an R package that allows users to remove parts of a fitted model
-object that are not needed for prediction.
+The \href{https://butcher.tidymodels.org/}{butcher} package allows you to remove
+parts of a fitted model object that are not needed for prediction.
 
 This bundle method is compatible with pre-butchering. That is, for a
-fitted model \code{x}, users can safely call:
+fitted model \code{x}, you can safely call:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{res <-
   x \%>\%

--- a/man/bundle_parsnip.Rd
+++ b/man/bundle_parsnip.Rd
@@ -56,6 +56,23 @@ Primarily, these methods call \code{\link[=bundle]{bundle()}} on the output of
 \code{\link[parsnip:reexports]{parsnip::extract_fit_engine()}}. See the class of the output of that
 function for more details on the bundling method for that object.
 }
+\section{bundle and butcher}{
+
+butcher is an R package that allows users to remove parts of a fitted model
+object that are not needed for prediction.
+
+This bundle method is compatible with pre-butchering. That is, for a
+fitted model \code{x}, users can safely call:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{res <-
+  x \%>\%
+  butcher() \%>\%
+  bundle()
+}\if{html}{\out{</div>}}
+
+and predict with the output of \code{unbundle(res)} in a new R session.
+}
+
 \examples{
 \dontshow{if (rlang::is_installed("parsnip") && rlang::is_installed("xgboost")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # fit model and bundle ------------------------------------------------

--- a/man/bundle_parsnip.Rd
+++ b/man/bundle_parsnip.Rd
@@ -58,11 +58,11 @@ function for more details on the bundling method for that object.
 }
 \section{bundle and butcher}{
 
-butcher is an R package that allows users to remove parts of a fitted model
-object that are not needed for prediction.
+The \href{https://butcher.tidymodels.org/}{butcher} package allows you to remove
+parts of a fitted model object that are not needed for prediction.
 
 This bundle method is compatible with pre-butchering. That is, for a
-fitted model \code{x}, users can safely call:
+fitted model \code{x}, you can safely call:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{res <-
   x \%>\%

--- a/man/bundle_workflows.Rd
+++ b/man/bundle_workflows.Rd
@@ -56,11 +56,11 @@ This bundler wraps \code{\link[=bundle.model_fit]{bundle.model_fit()}} and \code
 }
 \section{bundle and butcher}{
 
-butcher is an R package that allows users to remove parts of a fitted model
-object that are not needed for prediction.
+The \href{https://butcher.tidymodels.org/}{butcher} package allows you to remove
+parts of a fitted model object that are not needed for prediction.
 
 This bundle method is compatible with pre-butchering. That is, for a
-fitted model \code{x}, users can safely call:
+fitted model \code{x}, you can safely call:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{res <-
   x \%>\%

--- a/man/bundle_workflows.Rd
+++ b/man/bundle_workflows.Rd
@@ -54,6 +54,23 @@ more information on bundles and their usage.
 \details{
 This bundler wraps \code{\link[=bundle.model_fit]{bundle.model_fit()}} and \code{\link[=bundle.recipe]{bundle.recipe()}}.
 }
+\section{bundle and butcher}{
+
+butcher is an R package that allows users to remove parts of a fitted model
+object that are not needed for prediction.
+
+This bundle method is compatible with pre-butchering. That is, for a
+fitted model \code{x}, users can safely call:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{res <-
+  x \%>\%
+  butcher() \%>\%
+  bundle()
+}\if{html}{\out{</div>}}
+
+and predict with the output of \code{unbundle(res)} in a new R session.
+}
+
 \examples{
 \dontshow{if (rlang::is_installed(c("workflows", "parsnip", "recipes", "xgboost"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # fit model and bundle ------------------------------------------------

--- a/man/bundle_xgboost.Rd
+++ b/man/bundle_xgboost.Rd
@@ -52,11 +52,11 @@ more information on bundles and their usage.
 }
 \section{bundle and butcher}{
 
-butcher is an R package that allows users to remove parts of a fitted model
-object that are not needed for prediction.
+The \href{https://butcher.tidymodels.org/}{butcher} package allows you to remove
+parts of a fitted model object that are not needed for prediction.
 
 This bundle method is compatible with pre-butchering. That is, for a
-fitted model \code{x}, users can safely call:
+fitted model \code{x}, you can safely call:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{res <-
   x \%>\%

--- a/man/bundle_xgboost.Rd
+++ b/man/bundle_xgboost.Rd
@@ -50,6 +50,23 @@ Bundling a model prepares it to be saved to file and later
 restored for prediction in a new R session. See the 'Value' section for
 more information on bundles and their usage.
 }
+\section{bundle and butcher}{
+
+butcher is an R package that allows users to remove parts of a fitted model
+object that are not needed for prediction.
+
+This bundle method is compatible with pre-butchering. That is, for a
+fitted model \code{x}, users can safely call:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{res <-
+  x \%>\%
+  butcher() \%>\%
+  bundle()
+}\if{html}{\out{</div>}}
+
+and predict with the output of \code{unbundle(res)} in a new R session.
+}
+
 \examples{
 \dontshow{if (rlang::is_installed("xgboost")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # fit model and bundle ------------------------------------------------

--- a/tests/testthat/test_bundle_embed.R
+++ b/tests/testthat/test_bundle_embed.R
@@ -23,7 +23,7 @@ test_that("bundling + unbundling step_umap", {
   baked_data_unbundled <- bake(rec_unbundled, iris)
   expect_equal(baked_data, baked_data_unbundled)
 
-  baked_data_new <- callr::r(
+  bake_bundle_umap <-
     function(step_umap_bundled_) {
       library(bundle)
       library(recipes)
@@ -31,11 +31,28 @@ test_that("bundling + unbundling step_umap", {
 
       step_umap_unbundled <- unbundle(step_umap_bundled_)
       bake(step_umap_unbundled, iris)
-    },
+    }
+
+  baked_data_new <- callr::r(
+    bake_bundle_umap,
     args = list(
       step_umap_bundled_ = step_umap_bundled
     )
   )
 
   expect_equal(as.data.frame(baked_data), as.data.frame(baked_data_new))
+
+  # interaction with butcher
+  expect_silent({
+    rec_bundle_butchered <- bundle(butcher(rec))
+  })
+
+  baked_data_butchered <- callr::r(
+    bake_bundle_umap,
+    args = list(
+      step_umap_bundled_ = step_umap_bundled
+    )
+  )
+
+  expect_equal(as.data.frame(baked_data), as.data.frame(baked_data_butchered))
 })

--- a/tests/testthat/test_bundle_embed.R
+++ b/tests/testthat/test_bundle_embed.R
@@ -1,6 +1,10 @@
 test_that("bundling + unbundling step_umap", {
   skip_if_not_installed("embed")
+  skip_if_not_installed("butcher")
+
   library(embed)
+  library(butcher)
+
   skip_if_not(is_tf_available())
 
   set.seed(1)

--- a/tests/testthat/test_bundle_h2o.R
+++ b/tests/testthat/test_bundle_h2o.R
@@ -1,8 +1,11 @@
 test_that("bundling + unbundling h2o fits", {
   skip_if_not_installed("h2o")
   skip_if_not_installed("modeldata")
+  skip_if_not_installed("butcher")
+
   library(h2o)
   library(modeldata)
+  library(butcher)
 
   set.seed(1)
 

--- a/tests/testthat/test_bundle_h2o.R
+++ b/tests/testthat/test_bundle_h2o.R
@@ -160,4 +160,11 @@ test_that("bundling + unbundling h2o fits", {
   expect_equal(multi_preds$data, res$multi_unbundled_preds_new)
   expect_equal(auto_reg_preds$data, res$auto_reg_unbundled_preds_new)
   expect_equal(auto_bin_preds$data, res$auto_bin_unbundled_preds_new)
+
+  # interaction with butcher
+  expect_silent({
+    reg_fit_butchered <- butcher(reg_fit)
+  })
+
+  expect_equal(reg_fit, reg_fit_butchered)
 })

--- a/tests/testthat/test_bundle_keras.R
+++ b/tests/testthat/test_bundle_keras.R
@@ -60,14 +60,17 @@ test_that("bundling + unbundling keras fits", {
 
   # only want bundled model and original preds to persist.
   # test again in new R session:
-  mod_unbundled_preds_new <- callr::r(
+  predict_bundle_keras <-
     function(mod_bundle, x_test) {
       library(bundle)
       library(keras)
 
       mod_unbundled <- unbundle(mod_bundle)
       predict(mod_unbundled, x_test)
-    },
+    }
+
+  mod_unbundled_preds_new <- callr::r(
+    predict_bundle_keras,
     args = list(
       mod_bundle = mod_bundle,
       x_test = x_test
@@ -75,4 +78,19 @@ test_that("bundling + unbundling keras fits", {
   )
 
   expect_equal(mod_preds, mod_unbundled_preds_new)
+
+  # interaction with butcher
+  expect_silent({
+    mod_bundle_butchered <- bundle(butcher(mod))
+  })
+
+  mod_unbundled_preds_butchered <- callr::r(
+    predict_bundle_keras,
+    args = list(
+      mod_bundle = mod_bundle_butchered,
+      x_test = x_test
+    )
+  )
+
+  expect_equal(mod_preds, mod_unbundled_preds_butchered)
 })

--- a/tests/testthat/test_bundle_keras.R
+++ b/tests/testthat/test_bundle_keras.R
@@ -1,6 +1,9 @@
 test_that("bundling + unbundling keras fits", {
   skip_if_not_installed("keras")
+  skip_if_not_installed("butcher")
+
   library(keras)
+  library(butcher)
 
   set.seed(1)
 

--- a/tests/testthat/test_bundle_torch.R
+++ b/tests/testthat/test_bundle_torch.R
@@ -93,7 +93,7 @@ test_that("bundling + unbundling torch fits", {
 
   # only want bundled model and original preds to persist.
   # test again in new R session:
-  mod_unbundled_preds_new <- callr::r(
+  predict_bundle_torch <-
     function(mod_bundle, test_dl) {
       library(bundle)
       library(torch)
@@ -102,7 +102,10 @@ test_that("bundling + unbundling torch fits", {
 
       mod_unbundled <- unbundle(mod_bundle)
       as_array(predict(mod_unbundled, test_dl))
-    },
+    }
+
+  mod_unbundled_preds_new <- callr::r(
+    predict_bundle_torch,
     args = list(
       mod_bundle = mod_bundle,
       test_dl = test_dl
@@ -110,4 +113,19 @@ test_that("bundling + unbundling torch fits", {
   )
 
   expect_equal(mod_preds[1:100,1:100], mod_unbundled_preds_new[1:100,1:100])
+
+  # interaction with butcher
+  expect_silent({
+    mod_bundle_butchered <- bundle(butcher(mod))
+  })
+
+  mod_unbundled_preds_butchered <- callr::r(
+    predict_bundle_torch,
+    args = list(
+      mod_bundle = mod_bundle_butchered,
+      test_dl = test_dl
+    )
+  )
+
+  expect_equal(mod_preds[1:100,1:100], mod_unbundled_preds_butchered[1:100,1:100])
 })

--- a/tests/testthat/test_bundle_torch.R
+++ b/tests/testthat/test_bundle_torch.R
@@ -2,11 +2,13 @@ test_that("bundling + unbundling torch fits", {
   skip_if_not_installed("torch")
   skip_if_not_installed("torchvision")
   skip_if_not_installed("luz")
+  skip_if_not_installed("butcher")
   skip_on_cran()
 
   library(torch)
   library(torchvision)
   library(luz)
+  library(butcher)
 
   if (Sys.getenv("TORCH_HOME") == "") {
     skip("pytorch or lantern not installed")

--- a/tests/testthat/test_bundle_workflows.R
+++ b/tests/testthat/test_bundle_workflows.R
@@ -1,13 +1,15 @@
-test_that("bundling + unbundling tidymodels workflows (xgboost)", {
+test_that("bundling + unbundling tidymodels workflows (xgboost + step_log)", {
   skip_if_not_installed("workflows")
   skip_if_not_installed("parsnip")
   skip_if_not_installed("recipes")
   skip_if_not_installed("xgboost")
+  skip_if_not_installed("butcher")
 
   library(workflows)
   library(parsnip)
   library(recipes)
   library(xgboost)
+  library(butcher)
 
   set.seed(1)
 
@@ -42,7 +44,7 @@ test_that("bundling + unbundling tidymodels workflows (xgboost)", {
 
   # only want bundled model and original preds to persist.
   # test again in new R session:
-  mod_unbundled_preds_new <- callr::r(
+  predict_bundle_workflow <-
     function(mod_bundle_) {
       library(bundle)
       library(parsnip)
@@ -51,11 +53,113 @@ test_that("bundling + unbundling tidymodels workflows (xgboost)", {
 
       mod_unbundled_ <- unbundle(mod_bundle_)
       predict(mod_unbundled_, mtcars)
-    },
+    }
+
+  mod_unbundled_preds_new <- callr::r(
+    predict_bundle_workflow,
     args = list(
       mod_bundle_ = mod_bundle
     )
   )
 
   expect_equal(mod_preds, mod_unbundled_preds_new)
+
+  # interaction with butcher
+  expect_silent({
+    mod_bundle_butchered <- bundle(butcher(mod))
+  })
+
+  mod_unbundled_preds_butchered <- callr::r(
+    predict_bundle_workflow,
+    args = list(
+      mod_bundle_ = mod_bundle_butchered
+    )
+  )
+
+  expect_equal(mod_preds, mod_unbundled_preds_butchered)
+})
+
+test_that("bundling + unbundling tidymodels workflows (lm + step_umap)", {
+  skip_if_not_installed("workflows")
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("recipes")
+  skip_if_not_installed("embed")
+  skip_if_not_installed("butcher")
+
+  library(workflows)
+  library(parsnip)
+  library(recipes)
+  library(embed)
+  library(butcher)
+
+  skip_if_not(is_tf_available())
+
+  set.seed(1)
+
+  spec <-
+    linear_reg() %>%
+    set_mode("regression") %>%
+    set_engine("lm")
+
+  rec <-
+    recipe(mpg ~ ., data = mtcars) %>%
+    step_umap(all_predictors(), outcome = vars(mpg), num_comp = 2) %>%
+    prep()
+
+  mod <-
+    workflow() %>%
+    add_model(spec) %>%
+    add_recipe(rec) %>%
+    fit(data = mtcars)
+
+  mod_bundle <- bundle(mod)
+  mod_unbundled <- unbundle(mod_bundle)
+
+  expect_s3_class(mod_bundle, "bundled_workflow")
+  expect_s3_class(mod_unbundled, "workflow")
+
+  # ensure that the situater function didn't bring along the whole model
+  expect_false("x" %in% names(environment(mod$situate)))
+
+  mod_preds <- predict(mod, mtcars)
+  mod_unbundled_preds <- predict(mod_unbundled, new_data = mtcars)
+
+  expect_equal(mod_preds, mod_unbundled_preds)
+
+  # only want bundled model and original preds to persist.
+  # test again in new R session:
+  predict_bundle_workflow <-
+    function(mod_bundle_, estimated) {
+      library(bundle)
+      library(parsnip)
+      library(workflows)
+      library(recipes)
+      library(embed)
+
+      mod_unbundled_ <- unbundle(mod_bundle_)
+      predict(mod_unbundled_, mtcars)
+    }
+
+  mod_unbundled_preds_new <- callr::r(
+    predict_bundle_workflow,
+    args = list(
+      mod_bundle_ = mod_bundle
+    )
+  )
+
+  expect_equal(mod_preds, mod_unbundled_preds_new)
+
+  # interaction with butcher
+  expect_silent({
+    mod_bundle_butchered <- bundle(butcher(mod))
+  })
+
+  mod_unbundled_preds_butchered <- callr::r(
+    predict_bundle_workflow,
+    args = list(
+      mod_bundle_ = mod_bundle_butchered
+    )
+  )
+
+  expect_equal(mod_preds, mod_unbundled_preds_butchered)
 })

--- a/tests/testthat/test_bundle_xgboost.R
+++ b/tests/testthat/test_bundle_xgboost.R
@@ -1,6 +1,9 @@
 test_that("bundling + unbundling xgboost fits", {
   skip_if_not_installed("xgboost")
+  skip_if_not_installed("butcher")
+
   library(xgboost)
+  library(butcher)
 
   set.seed(1)
 
@@ -29,14 +32,16 @@ test_that("bundling + unbundling xgboost fits", {
 
   # only want bundled model and original preds to persist.
   # test again in new R session:
-  xgb_unbundled_preds_new <- callr::r(
-    function(xgb_bundle_, agaricus.test_) {
-      library(bundle)
-      library(xgboost)
+  predict_bundle_xgb <- function(xgb_bundle_, agaricus.test_) {
+    library(bundle)
+    library(xgboost)
 
-      xgb_unbundled <- unbundle(xgb_bundle_)
-      predict(xgb_unbundled, agaricus.test_$data)
-    },
+    xgb_unbundled <- unbundle(xgb_bundle_)
+    predict(xgb_unbundled, agaricus.test_$data)
+  }
+
+  xgb_unbundled_preds_new <- callr::r(
+    predict_bundle_xgb,
     args = list(
       xgb_bundle_ = xgb_bundle,
       agaricus.test_ = agaricus.test
@@ -44,4 +49,19 @@ test_that("bundling + unbundling xgboost fits", {
   )
 
   expect_equal(xgb_preds, xgb_unbundled_preds_new)
+
+  # interaction with butcher
+  expect_silent({
+    xgb_bundle_butchered <- bundle(butcher(xgb))
+  })
+
+  xgb_unbundled_preds_butchered <- callr::r(
+    predict_bundle_xgb,
+    args = list(
+      xgb_bundle_ = xgb_bundle_butchered,
+      agaricus.test_ = agaricus.test
+    )
+  )
+
+  expect_equal(xgb_preds, xgb_unbundled_preds_butchered)
 })


### PR DESCRIPTION
Closes #22.

Surprisingly, I couldn't find any examples of butchering before bundling resulting in errors. This PR adds tests for each of the bundle methods that directly wrap native serialization methods, as well as for the workflow setups described in #22, ensuring that we can butcher before bundling. 

I didn't add a vignette, as the story seems to be simpler than I had anticipated, but open to ideas for some docs here if you think this ought to be called out explicitly somewhere. :)

This PR also includes changes to `bundle.workflow` that the `lm + step_umap` tests needed—currently, the workflows bundler only bundled the recipe specification, but also needs to bundled the trained recipe.