### PR TITLE
add "Available methods" vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Suggests:
     caret,
     callr,
     covr,
+    dplyr,
     embed,
     h2o,
     keras,

--- a/vignettes/available-methods.Rmd
+++ b/vignettes/available-methods.Rmd
@@ -1,0 +1,63 @@
+---
+title: "Available bundling methods"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Available bundling methods}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+The following methods are currently available in `bundle`: 
+
+```{r table, echo = FALSE, warnings = FALSE, message = FALSE}
+library(bundle)
+library(dplyr)
+
+method_df <- function(method_name) {
+  m <- as.vector(utils::methods(method_name))
+  tibble::tibble(class = gsub(paste0(method_name, "[.]"), "", m),
+                 !!method_name := clisymbols::symbol$tick)
+}
+
+replace_na <- function(x) {
+  x[is.na(x)] <- " "
+  x
+}
+
+out <- method_df("bundle") %>% 
+  mutate(
+    package = case_when(
+      grepl("H2O", class) ~ "H2O",
+      class == "keras.engine.training.Model" ~ "keras",
+      class == "luz_module_fitted" ~ "torch",
+      class == "model_fit" ~ "parsnip",
+      class == "model_stack" ~ "stacks",
+      class == "recipe" ~ "recipes",
+      class == "step_umap" ~ "embed",
+      class == "train" ~ "caret",
+      class == "workflow" ~ "workflows",
+      class == "xgb.Booster" ~ "xgboost",
+      TRUE ~ ""
+    ),
+    ecosystem = case_when(
+      package %in% c("parsnip", "stacks", "recipes", 
+                     "embed", "workflows") ~ "tidymodels",
+      TRUE ~ ""
+    )
+  ) %>%
+  select(ecosystem, package, class) %>%
+  arrange(ecosystem, package, class) %>%
+  replace_na() %>%
+  knitr::kable()
+
+out
+```
+
+Note that a model object not being included in this table does not necessarily mean that the object cannot be saved and re-loaded in a new session---many model objects, like [stats::lm()](https://stat.ethz.ch/R-manual/R-devel/library/stats/html/lm.html) and [stats::glm()](https://stat.ethz.ch/R-manual/R-devel/library/stats/html/glm.html) output, can be effectively saved and re-loaded in a new session without any bundling!

--- a/vignettes/available-methods.Rmd
+++ b/vignettes/available-methods.Rmd
@@ -25,7 +25,7 @@ library(dplyr)
 method_df <- function(method_name) {
   m <- as.vector(utils::methods(method_name))
   tibble::tibble(class = gsub(paste0(method_name, "[.]"), "", m),
-                 !!method_name := clisymbols::symbol$tick)
+                 !!method_name := "x")
 }
 
 replace_na <- function(x) {

--- a/vignettes/available-methods.Rmd
+++ b/vignettes/available-methods.Rmd
@@ -12,11 +12,13 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
+
+should_eval <- rlang::is_installed("dplyr")
 ```
 
 The following methods are currently available in `bundle`: 
 
-```{r table, echo = FALSE, warnings = FALSE, message = FALSE}
+```{r table, echo = FALSE, warnings = FALSE, message = FALSE, eval = should_eval}
 library(bundle)
 library(dplyr)
 


### PR DESCRIPTION
I found this a bit trickier than anticipated, both in terms of finding a table structure that's informative and doing so in an automatically extensible way.

* Should ecosystem and package be merged, and "tidymodels" listed as the package? Thought ecosystem may be helpful with eventual introduction of mlr3.
* Should this be joined with the analogous butcher/broom table?

Very much open to revision!🦥

For ease of review:

<img width="1054" alt="A screenshot of a vignette written in markdown. The document is titled 'Available bundling methods,' and includes a three column table with columns ecosystem, package, and class, detailing what model objects are currently supported by bundle. There are 13 rows, with 4 allotted to tidymodels-specific bundlers." src="https://user-images.githubusercontent.com/35748691/184562886-a0f75a75-02d1-4fa2-93ec-3bad0b751ed7.png">


Closes #29. :)