### PR TITLE
Update keras bundle method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,6 @@ License: MIT + file LICENSE
 URL: https://github.com/rstudio/bundle, https://rstudio.github.io/bundle/
 BugReports: https://github.com/rstudio/bundle/issues
 Imports:
-    fs,
     glue,
     purrr,
     rlang,
@@ -30,6 +29,7 @@ Suggests:
     caret,
     covr,
     embed,
+    fs,
     h2o,
     keras,
     kernlab,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ License: MIT + file LICENSE
 URL: https://github.com/rstudio/bundle, https://rstudio.github.io/bundle/
 BugReports: https://github.com/rstudio/bundle/issues
 Imports:
+    fs,
     glue,
     purrr,
     rlang,
@@ -46,6 +47,7 @@ Suggests:
     torchvision,
     uwot,
     vetiver,
+    withr,
     workflows,
     xgboost
 VignetteBuilder: 

--- a/R/bundle_keras.R
+++ b/R/bundle_keras.R
@@ -69,8 +69,7 @@
 #' @method bundle keras.engine.training.Model
 #' @export
 bundle.keras.engine.training.Model <- function(x, ...) {
-  rlang::check_installed("keras")
-  rlang::check_installed("withr")
+  rlang::check_installed(c("keras", "withr", "fs"))
   rlang::check_dots_empty()
 
   file_loc <- fs::file_temp(pattern = "bundle", ext = ".tar.gz")

--- a/tests/testthat/test_bundle_keras.R
+++ b/tests/testthat/test_bundle_keras.R
@@ -1,6 +1,8 @@
 test_that("bundling + unbundling keras fits", {
   skip_if_not_installed("keras")
   skip_if_not_installed("butcher")
+  skip_if_not_installed("withr")
+  skip_if_not_installed("fs")
 
   library(keras)
   library(butcher)


### PR DESCRIPTION
Closes #37 


The keras method now writes the model to a directory, tars that directory, _serializes_ the tar file, then untars and loads the model at unbundle time.