### PR TITLE
Use local tempfiles from withr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,8 @@ Imports:
     glue,
     purrr,
     rlang,
-    utils
+    utils,
+    withr
 Suggests:
     bonsai,
     butcher,
@@ -29,7 +30,6 @@ Suggests:
     caret,
     covr,
     embed,
-    fs,
     h2o,
     keras,
     kernlab,
@@ -47,7 +47,6 @@ Suggests:
     torchvision,
     uwot,
     vetiver,
-    withr,
     workflows,
     xgboost
 VignetteBuilder: 

--- a/R/bundle_keras.R
+++ b/R/bundle_keras.R
@@ -72,8 +72,8 @@ bundle.keras.engine.training.Model <- function(x, ...) {
   rlang::check_installed(c("keras", "withr", "fs"))
   rlang::check_dots_empty()
 
-  file_loc <- fs::file_temp(pattern = "bundle", ext = ".tar.gz")
-  tmp_dir <- fs::dir_create(tempdir(), "bundle")
+  file_loc <- withr::local_tempfile(pattern = "bundle", fileext = ".tar.gz")
+  tmp_dir <- withr::local_tempdir("bundle")
   keras::save_model_tf(x, tmp_dir)
 
   withr::with_dir(
@@ -90,8 +90,8 @@ bundle.keras.engine.training.Model <- function(x, ...) {
   bundle_constr(
     object = serialized,
     situate = situate_constr(function(object) {
-      new_file <- fs::file_temp(pattern = "unbundle", ext = ".tar.gz")
-      unbundle_dir <- fs::dir_create(tempdir(), "unbundle")
+      new_file <- withr::local_tempfile(pattern = "unbundle", fileext = ".tar.gz")
+      unbundle_dir <- withr::local_tempdir("unbundle")
       writeBin(object, new_file, endian = "little")
       utils::untar(new_file, exdir = unbundle_dir)
       res <- keras::load_model_tf(unbundle_dir)

--- a/R/bundle_keras.R
+++ b/R/bundle_keras.R
@@ -69,7 +69,7 @@
 #' @method bundle keras.engine.training.Model
 #' @export
 bundle.keras.engine.training.Model <- function(x, ...) {
-  rlang::check_installed(c("keras", "withr", "fs"))
+  rlang::check_installed(c("keras"))
   rlang::check_dots_empty()
 
   file_loc <- withr::local_tempfile(pattern = "bundle", fileext = ".tar.gz")

--- a/tests/testthat/test_bundle_keras.R
+++ b/tests/testthat/test_bundle_keras.R
@@ -1,8 +1,6 @@
 test_that("bundling + unbundling keras fits", {
   skip_if_not_installed("keras")
   skip_if_not_installed("butcher")
-  skip_if_not_installed("withr")
-  skip_if_not_installed("fs")
 
   library(keras)
   library(butcher)


### PR DESCRIPTION
The functions in withr for temp files and temp directories [clean up after themselves](https://withr.r-lib.org/reference/with_tempfile.html), which is what we are looking for. It's a low dependency package that we now use across multiple bundling methods, so let's move it to Imports.