### PR TITLE
transition xgboost native serialization functions

### DIFF
--- a/R/bundle_xgboost.R
+++ b/R/bundle_xgboost.R
@@ -10,9 +10,8 @@
 #'   [xgboost::xgb.train()].
 #' @template param_unused_dots
 #' @rdname bundle_xgboost
-#' @seealso This method adapts the xgboost internal functions
-#'   `predict.xgb.Booster.handle()` and `xgb.handleToBooster()`, as well
-#'   as  [xgboost::xgb.serialize()].
+#' @seealso This method adapts the xgboost functions [xgboost::xgb.save.raw()]
+#'   and [xgboost::xgb.load.raw()].
 #' @template butcher_details
 #' @examplesIf rlang::is_installed("xgboost")
 #' # fit model and bundle ------------------------------------------------
@@ -40,16 +39,12 @@ bundle.xgb.Booster <- function(x, ...) {
   rlang::check_installed("xgboost")
   rlang::check_dots_empty()
 
-  object <- xgboost::xgb.serialize(x)
+  object <- xgboost::xgb.save.raw(x, raw_format = "ubj")
 
   bundle_constr(
     object = object,
     situate = situate_constr(function(object) {
-      unserialized <- xgboost::xgb.unserialize(object)
-
-      # see xgboost:::predict.xgb.Booster.handle and xgboost:::xgb.handleToBooster
-      res <- list(handle = unserialized, raw = NULL)
-      class(res) <- "xgb.Booster"
+      res <- xgboost::xgb.load.raw(object, as_booster = TRUE)
 
       res$params <- list(
         objective = !!x$params$objective,

--- a/man/bundle_xgboost.Rd
+++ b/man/bundle_xgboost.Rd
@@ -98,9 +98,8 @@ xgb_unbundled_preds <- predict(xgb_unbundled, agaricus.test$data)
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-This method adapts the xgboost internal functions
-\code{predict.xgb.Booster.handle()} and \code{xgb.handleToBooster()}, as well
-as  \code{\link[xgboost:xgb.serialize]{xgboost::xgb.serialize()}}.
+This method adapts the xgboost functions \code{\link[xgboost:xgb.save.raw]{xgboost::xgb.save.raw()}}
+and \code{\link[xgboost:xgb.load.raw]{xgboost::xgb.load.raw()}}.
 
 Other bundlers: 
 \code{\link{bundle.H2OAutoML}()},


### PR DESCRIPTION
Closes #43. Thank you for pointing this out, @juliasilge—this approach feels much better.

A relevant bit from the `xgb.save.raw` docs, where the `raw_format` default is `"deprecated"`:

```
raw_format: The format for encoding the booster. Available options are

* json: Encode the booster into JSON text document.
* ubj: Encode the booster into Universal Binary JSON.
* deprecated: Encode the booster into old customized binary format.
Right now the default is `deprecated` but will be changed to `ubj` in upcoming release.
```
