### PR TITLE
pass along nfeatures and feature_names to xgboost bundle

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * Added bundle method for objects from `dbarts::bart()` and, by extension,
   `parsnip::bart(engine = "dbarts")` (#64).
 
+* Bundling no longer removes `nfeatures` and `feature_names` from xgboost models (#67).
+
 # bundle 0.1.1
 
 * Fixed bundling of recipes steps situated inside of workflows.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 * Added bundle method for objects from `dbarts::bart()` and, by extension,
   `parsnip::bart(engine = "dbarts")` (#64).
 
-* Bundling no longer removes `nfeatures` and `feature_names` from xgboost models (#67).
+* Bundling xgboost objects now takes extra steps to preserve `nfeatures` and `feature_names` (#67).
 
 # bundle 0.1.1
 

--- a/R/bundle_xgboost.R
+++ b/R/bundle_xgboost.R
@@ -51,6 +51,9 @@ bundle.xgb.Booster <- function(x, ...) {
         num_class = !!x$params$num_class
       )
 
+      res$nfeatures <- !!x$nfeatures
+      res$feature_names <- !!x$feature_names
+
       res
     }),
     desc_class = class(x)[1]

--- a/tests/testthat/test_bundle_xgboost.R
+++ b/tests/testthat/test_bundle_xgboost.R
@@ -96,4 +96,8 @@ test_that("bundling + unbundling xgboost fits", {
   # compare predictions
   expect_equal(mod_preds, mod_unbundled_preds)
   expect_equal(mod_preds, mod_butchered_unbundled_preds)
+
+  # verify nfeatures and feature_names are kept
+  expect_identical(unbundle(mod_bundle)$nfeatures, mod_fit$nfeatures)
+  expect_identical(unbundle(mod_bundle)$feature_names, mod_fit$feature_names)
 })


### PR DESCRIPTION
Some functions that are applied to xgboost models use the `feature_names` and/or `nfeatures` element of the model. This PR makes sure they aren't removed when bundling.

Should close https://github.com/rstudio/bundle/issues/66 and deal with https://github.com/tidymodels/orbital/issues/61

``` r
library(tidymodels)
library(bundle)
library(orbital)

mod <- boost_tree(trees = 5, mtry = 3) %>%
  set_mode("regression") %>%
  set_engine("xgboost") %>%
  fit(mpg ~ ., data = mtcars[1:25,])

mod$fit$feature_names
#>  [1] "cyl"  "disp" "hp"   "drat" "wt"   "qsec" "vs"   "am"   "gear" "carb"

vip::vi(mod)
#> # A tibble: 4 × 2
#>   Variable Importance
#>   <chr>         <dbl>
#> 1 hp           0.498 
#> 2 wt           0.213 
#> 3 disp         0.212 
#> 4 drat         0.0774

mod_bundle <- bundle(mod)
mod_new <- unbundle(mod_bundle)

mod_new$fit$feature_names
#>  [1] "cyl"  "disp" "hp"   "drat" "wt"   "qsec" "vs"   "am"   "gear" "carb"

vip::vi(mod_new)
#> # A tibble: 4 × 2
#>   Variable Importance
#>   <chr>         <dbl>
#> 1 hp           0.498 
#> 2 wt           0.213 
#> 3 disp         0.212 
#> 4 drat         0.0774
```

<sup>Created on 2024-11-07 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>