### PR TITLE
make xgboost example version switched

### DIFF
--- a/R/bundle_xgboost.R
+++ b/R/bundle_xgboost.R
@@ -22,9 +22,15 @@
 #' data(agaricus.train)
 #' data(agaricus.test)
 #'
-#' xgb <- xgboost(data = agaricus.train$data, label = agaricus.train$label,
-#'                max_depth = 2, eta = 1, nthread = 2, nrounds = 2,
-#'                objective = "binary:logistic")
+#' if (utils::packageVersion("xgboost") >= "2.0.0.0") {
+#'   xgb <- xgboost(x = agaricus.train$data, y = agaricus.train$label,
+#'                  max_depth = 2, learning_rate = 1, nthread = 2, nrounds = 2,
+#'                  objective = "reg:squarederror")
+#' } else {
+#'   xgb <- xgboost(data = agaricus.train$data, label = agaricus.train$label,
+#'                  max_depth = 2, eta = 1, nthread = 2, nrounds = 2,
+#'                  objective = "binary:logistic")
+#' }
 #'
 #' xgb_bundle <- bundle(xgb)
 #'
@@ -56,7 +62,7 @@ bundle.xgb.Booster <- function(x, ...) {
         attr(res, "feature_names") <- !!attr(x, "feature_names")
       } else {
         res <- xgboost::xgb.load.raw(object, as_booster = TRUE)
-        
+
         res$params <- list(
           objective = !!x$params$objective,
           num_class = !!x$params$num_class

--- a/man/bundle_xgboost.Rd
+++ b/man/bundle_xgboost.Rd
@@ -85,9 +85,15 @@ set.seed(1)
 data(agaricus.train)
 data(agaricus.test)
 
-xgb <- xgboost(data = agaricus.train$data, label = agaricus.train$label,
-               max_depth = 2, eta = 1, nthread = 2, nrounds = 2,
-               objective = "binary:logistic")
+if (utils::packageVersion("xgboost") >= "2.0.0.0") {
+  xgb <- xgboost(x = agaricus.train$data, y = agaricus.train$label,
+                 max_depth = 2, learning_rate = 1, nthread = 2, nrounds = 2,
+                 objective = "reg:squarederror")
+} else {
+  xgb <- xgboost(data = agaricus.train$data, label = agaricus.train$label,
+                 max_depth = 2, eta = 1, nthread = 2, nrounds = 2,
+                 objective = "binary:logistic")
+}
 
 xgb_bundle <- bundle(xgb)
 


### PR DESCRIPTION
I recommend that later, 3-6 months or so that we convert to only accept 3.0.0.0 or higher for xgboost, but that seems too drastic right now